### PR TITLE
swap weechat for irssi

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jldugger@gmail.com'
 license 'GPL-2.0'
 description 'Installs/Configures pwnguin.net'
 long_description 'Installs/Configures pwnguin.net'
-version '1.3.6'
+version '1.4.0'
 
 chef_version '>= 12.5' if respond_to?(:chef_version)
 supports 'ubuntu'

--- a/recipes/shell.rb
+++ b/recipes/shell.rb
@@ -4,8 +4,14 @@
 #
 # Copyright (c) 2016 The Authors, All Rights Reserved.
 
-%w[screen git ack-grep colordiff sshguard irssi moreutils
+%w[screen git ack-grep colordiff sshguard moreutils
    myrepos pastebinit pwgen pv vim].each do |pkg|
+  package pkg do
+    action :upgrade
+  end
+end
+
+%w[weechat-curses weechat-plugins].each do |pkg|
   package pkg do
     action :upgrade
   end
@@ -18,7 +24,7 @@ user 'jldugger' do
 end
 
 cron 'irc' do
-  command '/usr/bin/screen -dmS IRC /usr/bin/irssi'
+  command '/usr/bin/screen -dmS IRC /usr/bin/weechat'
   time :reboot
   home '/home/jldugger'
   user 'jldugger'


### PR DESCRIPTION
Slack has closed off their IRC/XMPP gateway. Looks like weechat supports protocols a bit more broadly, let's try that instead.